### PR TITLE
Fix compatibility with upstream pg18@525392d5727f525392d5727f

### DIFF
--- a/include/pg_compat.h
+++ b/include/pg_compat.h
@@ -29,6 +29,11 @@ extern char *my_string_guc;
 /*--- Hooks prototypes and argument names ---*/
 
 /* ExecutorStart hook */
+#if PG_VERSION_NUM >= 180000
+#define EXEC_START_RET	bool
+#else
+#define EXEC_START_RET	void
+#endif
 #if PG_VERSION_NUM >= 100000
 #define EXECUTOR_START_HOOK_ARGS QueryDesc *queryDesc, \
 							int eflags

--- a/pg_extension_template.c
+++ b/pg_extension_template.c
@@ -56,7 +56,7 @@ static pgetSharedState *pget = NULL;
 
 PGDLLEXPORT void _PG_init(void);
 
-static void pget_ExecutorStart_hook(EXECUTOR_START_HOOK_ARGS);
+static EXEC_START_RET pget_ExecutorStart_hook(EXECUTOR_START_HOOK_ARGS);
 static ExecutorStart_hook_type prev_ExecutorStart = NULL;
 
 static void pget_ExecutorRun_hook(EXECUTOR_RUN_HOOK_ARGS);
@@ -191,13 +191,13 @@ _PG_init(void)
 /*
  * ExecutorStart hook
  */
-static void
+static EXEC_START_RET
 pget_ExecutorStart_hook(EXECUTOR_START_HOOK_ARGS)
 {
 	if (prev_ExecutorStart)
-		prev_ExecutorStart(EXECUTOR_START_HOOK_ARG_NAMES);
+		return prev_ExecutorStart(EXECUTOR_START_HOOK_ARG_NAMES);
 	else
-		standard_ExecutorStart(EXECUTOR_START_HOOK_ARG_NAMES);
+		return standard_ExecutorStart(EXECUTOR_START_HOOK_ARG_NAMES);
 }
 
 /*


### PR DESCRIPTION
This commit changed the ExecutorStart return type.